### PR TITLE
Implement basic Corsica guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # appli
 
-A new Flutter project.
+Guide touristique simplifié de la Corse. Ce projet démontre comment afficher
+quelques destinations emblématiques de l'île à l'aide de Flutter.
+Les données pourront être enrichies grâce au portail open data
+[data.corsica](https://www.data.corsica/pages/portail/).
 
 ## Getting Started
 

--- a/lib/destination_page.dart
+++ b/lib/destination_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class Destination {
+  final String name;
+  final String description;
+
+  const Destination(this.name, this.description);
+}
+
+const List<Destination> destinations = [
+  Destination('Ajaccio',
+      'Capitale de la Corse du Sud, connue pour sa vieille ville et sa cathédrale.'),
+  Destination('Bonifacio',
+      'Ville perchée sur des falaises de calcaire blanc offrant un panorama exceptionnel.'),
+  Destination('Calvi',
+      'Port de plaisance réputé pour sa citadelle génoise et ses plages.'),
+];
+
+class DestinationPage extends StatelessWidget {
+  const DestinationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Guide de la Corse')),
+      body: ListView.builder(
+        itemCount: destinations.length,
+        itemBuilder: (context, index) {
+          final dest = destinations[index];
+          return Card(
+            margin: const EdgeInsets.all(8),
+            child: ListTile(
+              title: Text(dest.name),
+              subtitle: Text(dest.description),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'destination_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,93 +31,8 @@ class MyApp extends StatelessWidget {
         // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const DestinationPage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: appli
-description: "A new Flutter project."
+description: "Guide touristique simplifié de la Corse"
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  google_maps_flutter: ^2.2.5
+  google_mobile_ads: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Résumé
- présentation d'un petit guide de la Corse dans le README
- ajout d'une page `DestinationPage` listant quelques lieux emblématiques
- simplification de `main.dart` pour afficher cette page
- mise à jour du `pubspec.yaml` avec une description adaptée et les dépendances pour Google Maps et la publicité

## Tests
- `flutter test` (échoue : `flutter` introuvable)


------
https://chatgpt.com/codex/tasks/task_e_685edba34fec832d997abe8666cc9b99