### PR TITLE
Supprime google_mobile_ads

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -144,14 +144,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.12+2"
-  google_mobile_ads:
-    dependency: "direct main"
-    description:
-      name: google_mobile_ads
-      sha256: "7b8915f0ad358f49ba7d547b5187204cfe72ca668fb83aa303f96a2eacdc4033"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,6 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   google_maps_flutter: ^2.2.5
-  google_mobile_ads: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- retire `google_mobile_ads` de `pubspec.yaml`
- nettoie l'entrée correspondante dans `pubspec.lock`
- la commande `flutter pub get` n'a pas pu être exécutée car Flutter n'est pas installé dans l'environnement

## Testing
- `flutter pub get` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee53f1be0832d952f72126525393c