### PR TITLE
Ajout fonctionalités de navigation et favoris

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ quelques destinations emblématiques de l'île à l'aide de Flutter.
 Les données pourront être enrichies grâce au portail open data
 [data.corsica](https://www.data.corsica/pages/portail/).
 
+## Fonctionnalités
+
+- Page d'accueil avec introduction et accès aux destinations
+- Mode sombre activable depuis l'interface
+- Système de favoris enregistré localement
+- Accès rapide à la carte pour chaque lieu
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.

--- a/lib/destination_page.dart
+++ b/lib/destination_page.dart
@@ -1,37 +1,65 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class Destination {
   final String name;
   final String description;
+  final double lat;
+  final double lng;
 
-  const Destination(this.name, this.description);
+  const Destination(this.name, this.description, this.lat, this.lng);
 }
 
 const List<Destination> destinations = [
-  Destination('Ajaccio',
-      'Capitale de la Corse du Sud, connue pour sa vieille ville et sa cathédrale.'),
-  Destination('Bonifacio',
-      'Ville perchée sur des falaises de calcaire blanc offrant un panorama exceptionnel.'),
-  Destination('Calvi',
-      'Port de plaisance réputé pour sa citadelle génoise et ses plages.'),
+  Destination('Ajaccio', 'Capitale de la Corse du Sud, connue pour sa vieille ville et sa cathédrale.', 41.919229, 8.738635),
+  Destination('Bonifacio', 'Ville perchée sur des falaises de calcaire blanc offrant un panorama exceptionnel.', 41.3879, 9.159),
+  Destination('Calvi', 'Port de plaisance réputé pour sa citadelle génoise et ses plages.', 42.559, 8.758),
 ];
 
 class DestinationPage extends StatelessWidget {
-  const DestinationPage({super.key});
+  final Set<String> favorites;
+  final ValueChanged<String> onToggleFavorite;
+
+  const DestinationPage({
+    required this.favorites,
+    required this.onToggleFavorite,
+    super.key,
+  });
+
+  Future<void> _openMap(double lat, double lng) async {
+    final url = Uri.parse('https://www.google.com/maps/search/?api=1&query=\$lat,\$lng');
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Guide de la Corse')),
+      appBar: AppBar(title: const Text('Destinations')),
       body: ListView.builder(
         itemCount: destinations.length,
         itemBuilder: (context, index) {
           final dest = destinations[index];
+          final isFav = favorites.contains(dest.name);
           return Card(
             margin: const EdgeInsets.all(8),
             child: ListTile(
               title: Text(dest.name),
               subtitle: Text(dest.description),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: Icon(isFav ? Icons.star : Icons.star_border, color: Colors.amber),
+                    onPressed: () => onToggleFavorite(dest.name),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.map),
+                    onPressed: () => _openMap(dest.lat, dest.lng),
+                  ),
+                ],
+              ),
             ),
           );
         },

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'destination_page.dart';
+
+class HomePage extends StatelessWidget {
+  final ThemeMode themeMode;
+  final ValueChanged<bool> onToggleTheme;
+  final Set<String> favorites;
+  final ValueChanged<String> onToggleFavorite;
+
+  const HomePage({
+    required this.themeMode,
+    required this.onToggleTheme,
+    required this.favorites,
+    required this.onToggleFavorite,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Guide Corse'),
+        actions: [
+          Row(
+            children: [
+              const Icon(Icons.dark_mode),
+              Switch(
+                value: themeMode == ThemeMode.dark,
+                onChanged: onToggleTheme,
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Découvrez les plus belles destinations de Corse',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => DestinationPage(
+                      favorites: favorites,
+                      onToggleFavorite: onToggleFavorite,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Voir les destinations'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,38 +1,78 @@
 import 'package:flutter/material.dart';
-import 'destination_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'home_page.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  ThemeMode _themeMode = ThemeMode.light;
+  final Set<String> _favorites = <String>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrefs();
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final favs = prefs.getStringList('favorites') ?? <String>[];
+    _favorites.addAll(favs);
+    final isDark = prefs.getBool('darkMode') ?? false;
+    setState(() {
+      _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+    });
+  }
+
+  Future<void> _savePrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList('favorites', _favorites.toList());
+    await prefs.setBool('darkMode', _themeMode == ThemeMode.dark);
+  }
+
+  void _toggleTheme(bool value) {
+    setState(() {
+      _themeMode = value ? ThemeMode.dark : ThemeMode.light;
+    });
+    _savePrefs();
+  }
+
+  void _toggleFavorite(String name) {
+    setState(() {
+      if (_favorites.contains(name)) {
+        _favorites.remove(name);
+      } else {
+        _favorites.add(name);
+      }
+    });
+    _savePrefs();
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Guide Corse',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
       ),
-      home: const DestinationPage(),
+      darkTheme: ThemeData.dark(),
+      themeMode: _themeMode,
+      home: HomePage(
+        themeMode: _themeMode,
+        onToggleTheme: _toggleTheme,
+        favorites: _favorites,
+        onToggleFavorite: _toggleFavorite,
+      ),
     );
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   google_maps_flutter: ^2.2.5
+  shared_preferences: ^2.2.2
+  url_launcher: ^6.1.11
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,11 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:appli/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Home page shows welcome text', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Découvrez les plus belles destinations de Corse'), findsOneWidget);
+    expect(find.text('Voir les destinations'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Résumé
- nouvelle page d'accueil avec bouton vers les destinations
- mode sombre activable via un interrupteur
- gestion des favoris enregistrés localement
- accès rapide aux cartes Google depuis chaque lieu
- mise à jour du test widget

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_685ee5fd62b8832d80817339d3b944fb