### PR TITLE
Add interactive map and public data page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Guide touristique simplifié de la Corse. Ce projet démontre comment afficher
 quelques destinations emblématiques de l'île à l'aide de Flutter.
-Les données pourront être enrichies grâce au portail open data
+Les données sont récupérées depuis le portail open data
 [data.corsica](https://www.data.corsica/pages/portail/).
 
 ## Fonctionnalités
@@ -10,7 +10,9 @@ Les données pourront être enrichies grâce au portail open data
 - Page d'accueil avec introduction et accès aux destinations
 - Mode sombre activable depuis l'interface
 - Système de favoris enregistré localement
-- Accès rapide à la carte pour chaque lieu
+- Cartes interactives intégrées pour chaque lieu
+- Images illustratives pour les destinations
+- Nouvelle page listant des données publiques issues de data.corsica
 
 ## Getting Started
 

--- a/lib/data_page.dart
+++ b/lib/data_page.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class DataPage extends StatelessWidget {
+  const DataPage({super.key});
+
+  Future<List<String>> _fetchData() async {
+    final response = await http.get(
+      Uri.parse('https://www.data.corsica/api/records/1.0/search/?dataset=lieux-culturels&rows=10'),
+    );
+    if (response.statusCode == 200) {
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final records = json['records'] as List<dynamic>;
+      return records
+          .map((e) => e['fields']['nom']?.toString() ?? 'Inconnu')
+          .toList();
+    }
+    throw Exception('Erreur lors du chargement');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Données publiques')),
+      body: FutureBuilder<List<String>>(
+        future: _fetchData(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Erreur: ${snapshot.error}'));
+          } else {
+            final items = snapshot.data ?? [];
+            return ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                return ListTile(title: Text(items[index]));
+              },
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/destination_page.dart
+++ b/lib/destination_page.dart
@@ -1,19 +1,45 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'map_page.dart';
 
 class Destination {
   final String name;
   final String description;
   final double lat;
   final double lng;
+  final String imageUrl;
 
-  const Destination(this.name, this.description, this.lat, this.lng);
+  const Destination(
+    this.name,
+    this.description,
+    this.lat,
+    this.lng,
+    this.imageUrl,
+  );
 }
 
 const List<Destination> destinations = [
-  Destination('Ajaccio', 'Capitale de la Corse du Sud, connue pour sa vieille ville et sa cathédrale.', 41.919229, 8.738635),
-  Destination('Bonifacio', 'Ville perchée sur des falaises de calcaire blanc offrant un panorama exceptionnel.', 41.3879, 9.159),
-  Destination('Calvi', 'Port de plaisance réputé pour sa citadelle génoise et ses plages.', 42.559, 8.758),
+  Destination(
+    'Ajaccio',
+    'Capitale de la Corse du Sud, connue pour sa vieille ville et sa cathédrale.',
+    41.919229,
+    8.738635,
+    'https://upload.wikimedia.org/wikipedia/commons/8/80/Ajaccio_vue.jpg',
+  ),
+  Destination(
+    'Bonifacio',
+    'Ville perchée sur des falaises de calcaire blanc offrant un panorama exceptionnel.',
+    41.3879,
+    9.159,
+    'https://upload.wikimedia.org/wikipedia/commons/b/b2/Bonifacio_haut.jpg',
+  ),
+  Destination(
+    'Calvi',
+    'Port de plaisance réputé pour sa citadelle génoise et ses plages.',
+    42.559,
+    8.758,
+    'https://upload.wikimedia.org/wikipedia/commons/5/5f/Calvi_vue.jpg',
+  ),
 ];
 
 class DestinationPage extends StatelessWidget {
@@ -26,11 +52,15 @@ class DestinationPage extends StatelessWidget {
     super.key,
   });
 
-  Future<void> _openMap(double lat, double lng) async {
-    final url = Uri.parse('https://www.google.com/maps/search/?api=1&query=\$lat,\$lng');
-    if (await canLaunchUrl(url)) {
-      await launchUrl(url, mode: LaunchMode.externalApplication);
-    }
+  void _openMap(BuildContext context, Destination dest) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => MapPage(
+          position: LatLng(dest.lat, dest.lng),
+          title: dest.name,
+        ),
+      ),
+    );
   }
 
   @override
@@ -45,6 +75,7 @@ class DestinationPage extends StatelessWidget {
           return Card(
             margin: const EdgeInsets.all(8),
             child: ListTile(
+              leading: Image.network(dest.imageUrl, width: 50, height: 50, fit: BoxFit.cover),
               title: Text(dest.name),
               subtitle: Text(dest.description),
               trailing: Row(
@@ -56,7 +87,7 @@ class DestinationPage extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.map),
-                    onPressed: () => _openMap(dest.lat, dest.lng),
+                    onPressed: () => _openMap(context, dest),
                   ),
                 ],
               ),

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'destination_page.dart';
+import 'data_page.dart';
 
 class HomePage extends StatelessWidget {
   final ThemeMode themeMode;
@@ -53,6 +54,17 @@ class HomePage extends StatelessWidget {
                 );
               },
               child: const Text('Voir les destinations'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const DataPage(),
+                  ),
+                );
+              },
+              child: const Text('Explorer les données publiques'),
             ),
           ],
         ),

--- a/lib/map_page.dart
+++ b/lib/map_page.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class MapPage extends StatelessWidget {
+  final LatLng position;
+  final String title;
+
+  const MapPage({required this.position, required this.title, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: GoogleMap(
+        initialCameraPosition: CameraPosition(target: position, zoom: 12),
+        markers: {
+          Marker(
+            markerId: const MarkerId('dest'),
+            position: position,
+            infoWindow: InfoWindow(title: title),
+          ),
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   google_maps_flutter: ^2.2.5
   shared_preferences: ^2.2.2
   url_launcher: ^6.1.11
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add integrated map view with `google_maps_flutter`
- show images for each destination
- fetch and display open data from data.corsica
- link the new pages from the home page
- document features

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eecb51314832d93be47ff6285e0a7