### PR TITLE
Amélioration interface et ajout d'exercices JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Ce projet propose des leçons interactives pour découvrir les bases du corse.
 - Mode sombre activable depuis l'interface
 - Premières leçons avec questions à choix multiples
 - Progression simple indiquée par des messages de validation
+- Questions chargées depuis un fichier JSON
+- Couleurs inspirées de Duolingo
 
 ## Getting Started
 

--- a/assets/lessons.json
+++ b/assets/lessons.json
@@ -1,0 +1,19 @@
+{
+  "lessons": [
+    {
+      "question": "Comment dit-on \"bonjour\" en corse ?",
+      "options": ["Bonghjornu", "Salute", "Ciao"],
+      "answer": "Bonghjornu"
+    },
+    {
+      "question": "Comment dit-on \"merci\" en corse ?",
+      "options": ["Grazie", "Per piacè", "Salute"],
+      "answer": "Grazie"
+    },
+    {
+      "question": "Que signifie \"a casa\" ?",
+      "options": ["La maison", "La plage", "La montagne"],
+      "answer": "La maison"
+    }
+  ]
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -31,12 +31,18 @@ class HomePage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text(
+            Text(
               'Commencez votre apprentissage du corse',
+              style: Theme.of(context).textTheme.headlineMedium,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 16),
             ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF58CC02),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+              ),
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(

--- a/lib/lesson_page.dart
+++ b/lib/lesson_page.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
 class LessonPage extends StatefulWidget {
   const LessonPage({super.key});
@@ -7,17 +9,46 @@ class LessonPage extends StatefulWidget {
   State<LessonPage> createState() => _LessonPageState();
 }
 
+class Lesson {
+  final String question;
+  final List<String> options;
+  final String answer;
+
+  Lesson({required this.question, required this.options, required this.answer});
+
+  factory Lesson.fromJson(Map<String, dynamic> json) {
+    return Lesson(
+      question: json['question'] as String,
+      options: List<String>.from(json['options'] as List<dynamic>),
+      answer: json['answer'] as String,
+    );
+  }
+}
+
 class _LessonPageState extends State<LessonPage> {
-  final String question = 'Comment dit-on "bonjour" en corse ?';
-  final List<String> options = ['Bonghjornu', 'Salute', 'Ciao'];
-  final String correctAnswer = 'Bonghjornu';
+  late Future<List<Lesson>> _lessonsFuture;
+  int _currentIndex = 0;
   String? selected;
+  late List<Lesson> _loadedLessons;
+
+  @override
+  void initState() {
+    super.initState();
+    _lessonsFuture = _loadLessons();
+  }
+
+  Future<List<Lesson>> _loadLessons() async {
+    final data = await rootBundle.loadString('assets/lessons.json');
+    final jsonMap = jsonDecode(data) as Map<String, dynamic>;
+    final list = jsonMap['lessons'] as List<dynamic>;
+    return list.map((e) => Lesson.fromJson(e as Map<String, dynamic>)).toList();
+  }
 
   void _select(String value) {
     setState(() {
       selected = value;
     });
-    final isCorrect = value == correctAnswer;
+    final isCorrect = value == _loadedLessons[_currentIndex].answer;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(isCorrect ? 'Correct !' : 'Incorrect')),
     );
@@ -29,20 +60,36 @@ class _LessonPageState extends State<LessonPage> {
       appBar: AppBar(title: const Text('Leçon')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(question, style: Theme.of(context).textTheme.titleLarge),
-            const SizedBox(height: 24),
-            for (final option in options)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                child: ElevatedButton(
-                  onPressed: () => _select(option),
-                  child: Text(option),
-                ),
-              ),
-          ],
+        child: FutureBuilder<List<Lesson>>(
+          future: _lessonsFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (snapshot.hasError) {
+              return Center(child: Text('Erreur: ${snapshot.error}'));
+            } else {
+              _loadedLessons = snapshot.data!;
+              final lesson = _loadedLessons[_currentIndex];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    lesson.question,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 24),
+                  for (final option in lesson.options)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      child: ElevatedButton(
+                        onPressed: () => _select(option),
+                        child: Text(option),
+                      ),
+                    ),
+                ],
+              );
+            }
+          },
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,7 +48,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Corsican Lingo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF58CC02)),
         useMaterial3: true,
       ),
       darkTheme: ThemeData.dark(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,9 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - assets/lessons.json
+
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
## Résumé
- couleurs inspirées de Duolingo
- questions de leçon chargées depuis `assets/lessons.json`
- amélioration de la page d'accueil et des boutons
- mise à jour de la configuration des assets

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_685ef1c81b1c832dafdbed1eaf6fdd4b