### PR TITLE
Ajout de tests widgets

### DIFF
--- a/test/destination_favorite_test.dart
+++ b/test/destination_favorite_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appli/destination_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('Ajout d\'un favori et persistance', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final favorites = <String>{};
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DestinationPage(
+          favorites: favorites,
+          onToggleFavorite: (name) {
+            favorites.add(name);
+            prefs.setStringList('favorites', favorites.toList());
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.star_border).first);
+    await tester.pump();
+
+    expect(favorites.contains(destinations.first.name), isTrue);
+    expect(prefs.getStringList('favorites'), contains(destinations.first.name));
+  });
+}

--- a/test/lesson_progress_test.dart
+++ b/test/lesson_progress_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appli/lesson_page.dart';
+
+void main() {
+  testWidgets('Sélection de la bonne réponse affiche Correct !', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: LessonPage()));
+    await tester.pumpAndSettle();
+
+    const bonneReponse = 'Bonghjornu';
+    final correctFinder = find.widgetWithText(ElevatedButton, bonneReponse);
+    await tester.tap(correctFinder);
+    await tester.pump();
+
+    expect(find.text('Correct !'), findsOneWidget);
+  });
+}

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appli/main.dart';
+
+void main() {
+  testWidgets('BottomNavigationBar affiche les onglets', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    // Vérifie la présence du BottomNavigationBar
+    final barFinder = find.byType(BottomNavigationBar);
+    expect(barFinder, findsOneWidget);
+
+    final bar = tester.widget<BottomNavigationBar>(barFinder);
+    final labels = bar.items.map((item) => item.label).toList();
+
+    expect(labels, contains('Accueil'));
+    expect(labels, contains('Destinations'));
+    expect(labels, contains('Données'));
+  });
+}


### PR DESCRIPTION
## Résumé
- ajout d’un test vérifiant les onglets du `BottomNavigationBar`
- ajout d’un test simulant l’ajout d’un favori dans `DestinationPage` avec persistance `SharedPreferences`
- ajout d’un test vérifiant l’affichage du message `Correct !` après une bonne réponse dans `LessonPage`

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_685ef38e8290832d863dce16ae84d770