### PR TITLE
Ajout favoris destinations

### DIFF
--- a/lib/destination_page.dart
+++ b/lib/destination_page.dart
@@ -42,7 +42,7 @@ const List<Destination> destinations = [
   ),
 ];
 
-class DestinationPage extends StatelessWidget {
+class DestinationPage extends StatefulWidget {
   final Set<String> favorites;
   final ValueChanged<String> onToggleFavorite;
 
@@ -51,6 +51,13 @@ class DestinationPage extends StatelessWidget {
     required this.onToggleFavorite,
     super.key,
   });
+
+  @override
+  State<DestinationPage> createState() => _DestinationPageState();
+}
+
+class _DestinationPageState extends State<DestinationPage> {
+  bool _showOnlyFavorites = false;
 
   void _openMap(BuildContext context, Destination dest) {
     Navigator.of(context).push(
@@ -65,13 +72,30 @@ class DestinationPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final items = _showOnlyFavorites
+        ? destinations.where((d) => widget.favorites.contains(d.name)).toList()
+        : destinations;
     return Scaffold(
-      appBar: AppBar(title: const Text('Destinations')),
+      appBar: AppBar(
+        title: const Text('Destinations'),
+        actions: [
+          IconButton(
+            icon: Icon(
+              _showOnlyFavorites ? Icons.star : Icons.star_border,
+            ),
+            onPressed: () {
+              setState(() {
+                _showOnlyFavorites = !_showOnlyFavorites;
+              });
+            },
+          ),
+        ],
+      ),
       body: ListView.builder(
-        itemCount: destinations.length,
+        itemCount: items.length,
         itemBuilder: (context, index) {
-          final dest = destinations[index];
-          final isFav = favorites.contains(dest.name);
+          final dest = items[index];
+          final isFav = widget.favorites.contains(dest.name);
           return Card(
             margin: const EdgeInsets.all(8),
             child: ListTile(
@@ -83,7 +107,7 @@ class DestinationPage extends StatelessWidget {
                 children: [
                   IconButton(
                     icon: Icon(isFav ? Icons.star : Icons.star_border, color: Colors.amber),
-                    onPressed: () => onToggleFavorite(dest.name),
+                    onPressed: () => widget.onToggleFavorite(dest.name),
                   ),
                   IconButton(
                     icon: const Icon(Icons.map),

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
 import 'lesson_page.dart';
+import 'destination_page.dart';
 
 class HomePage extends StatelessWidget {
   final ThemeMode themeMode;
   final ValueChanged<bool> onToggleTheme;
+  final Set<String> favorites;
+  final ValueChanged<String> onToggleFavorite;
   const HomePage({
     required this.themeMode,
     required this.onToggleTheme,
+    required this.favorites,
+    required this.onToggleFavorite,
     super.key,
   });
 
@@ -51,6 +56,25 @@ class HomePage extends StatelessWidget {
                 );
               },
               child: const Text('Commencer les leçons'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF58CC02),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+              ),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => DestinationPage(
+                      favorites: favorites,
+                      onToggleFavorite: onToggleFavorite,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Explorer les destinations'),
             ),
           ],
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   ThemeMode _themeMode = ThemeMode.light;
+  Set<String> _favorites = <String>{};
 
   @override
   void initState() {
@@ -25,19 +26,33 @@ class _MyAppState extends State<MyApp> {
   Future<void> _loadPrefs() async {
     final prefs = await SharedPreferences.getInstance();
     final isDark = prefs.getBool('darkMode') ?? false;
+    final favList = prefs.getStringList('favorites') ?? <String>[];
     setState(() {
       _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+      _favorites = favList.toSet();
     });
   }
 
   Future<void> _savePrefs() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('darkMode', _themeMode == ThemeMode.dark);
+    await prefs.setStringList('favorites', _favorites.toList());
   }
 
   void _toggleTheme(bool value) {
     setState(() {
       _themeMode = value ? ThemeMode.dark : ThemeMode.light;
+    });
+    _savePrefs();
+  }
+
+  void _toggleFavorite(String name) {
+    setState(() {
+      if (_favorites.contains(name)) {
+        _favorites.remove(name);
+      } else {
+        _favorites.add(name);
+      }
     });
     _savePrefs();
   }
@@ -56,6 +71,8 @@ class _MyAppState extends State<MyApp> {
       home: HomePage(
         themeMode: _themeMode,
         onToggleTheme: _toggleTheme,
+        favorites: _favorites,
+        onToggleFavorite: _toggleFavorite,
       ),
     );
   }


### PR DESCRIPTION
## Résumé
- récupération des favoris depuis `SharedPreferences`
- passage des favoris au `HomePage` et au `DestinationPage`
- sauvegarde des favoris après chaque modification
- ajout d'un bouton d'accès aux destinations sur la page d'accueil
- possibilité de filtrer les destinations par favoris

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_685ef382b908832d9638784430ce84b0